### PR TITLE
chore: add updateTypes to renovate package rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "packages": [
     {
       "packageName": "yaml",
+      "updateTypes": ["major", "minor", "patch"],
       "automerge": false
     }
   ]


### PR DESCRIPTION
Adding this extra config ensures it overrules the parent config, which itself enabled `automerge`.