### PR TITLE
Revert "chore(deps): update dependency yaml to v1.0.0-rc.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tslint-config-prettier": "1.13.0",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "2.9.2",
-    "yaml": "1.0.0-rc.5"
+    "yaml": "1.0.0-rc.4"
   },
   "peerDependencies": {
     "yaml": "^1.0.0-rc.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4113,9 +4113,9 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
-yaml@1.0.0-rc.5:
-  version "1.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.0.0-rc.5.tgz#113aad47e7a6c1c59759fb318459e42b96708021"
+yaml@1.0.0-rc.4:
+  version "1.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.0.0-rc.4.tgz#850dc77d9b03975b5e5ea8a9b37cde252a8f1f0b"
 
 yargs-parser@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Reverts ikatyang/yaml-unist-parser#41

Ref: https://github.com/renovatebot/renovate/issues/2180#issuecomment-402894322

(Not sure why directly click <kbd>Revert</kbd> on #41 will include #44 -> 418906a1f2c64484b05fffc3410883f46c1a2595)